### PR TITLE
adding-thermal-dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - jupyterlab
   - altair
   - vl-convert-python
-  - rasterio
   - pytest-qt
   - pyqt
   - git

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,38 @@
+# run: conda env create --file environment.yml
+# optionally, change channel name with -n {plantcv-dev}
+name: plantcv
+dependencies:
+  - python=3.11
+  - pip:
+    - flirextractor
+  - matplotlib>=1.5
+  - numpy>=1.11,<2
+  - pandas
+  - python-dateutil
+  - scipy
+  - scikit-image>=0.19
+  - scikit-learn
+  - dask
+  - dask-jobqueue
+  - opencv
+  - statsmodels
+  - xarray>=2022.11.0
+  - mkdocs
+  - pytest
+  - pytest-cov
+  - flake8
+  - ipympl
+  - nodejs
+  - jupyterlab
+  - altair
+  - vl-convert-python
+  - rasterio
+  - napari
+  - pytest-qt
+  - pyqt
+  - git
+  - exiftools
+
+channels:
+  - conda-forge
+  - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@
 name: plantcv
 dependencies:
   - python=3.11
+  - pip
   - pip:
     - flirextractor
   - matplotlib>=1.5
@@ -27,11 +28,10 @@ dependencies:
   - altair
   - vl-convert-python
   - rasterio
-  - napari
   - pytest-qt
   - pyqt
   - git
-  - exiftools
+  - exiftool
 
 channels:
   - conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ name = "plantcv-extras"
 dynamic = ["version"]
 dependencies = [
     "plantcv",
-    "exiftool",
-    "pip",
     "flirextractor",
 ]
 requires-python = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ name = "plantcv-extras"
 dynamic = ["version"]
 dependencies = [
     "plantcv",
+    "exiftool",
+    "pip",
+    "flirextractor",
 ]
 requires-python = ">=3.6"
 authors = [


### PR DESCRIPTION
**Describe your changes**
Added exiftools and flirextractor as dependencies for plantcv-extras

**Type of update**
Is this a:
* New feature or feature enhancement


**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
FLIR thermal images require exiftools to read thermal jpg metadata and flirextractor is a package for converting thermal jpgs to csv. 

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
